### PR TITLE
2.3 support, auto-switch between beta/stable runtimes, some cleanup

### DIFF
--- a/build.js
+++ b/build.js
@@ -122,9 +122,9 @@ Builder = Object.assign(Builder, {
             }
         });
 
-        Builder.Compiler.on("close", (e) => {
+        Builder.Compiler.on("close", (exitCode) => {
             // Rename output file!
-            if (Builder.Compiler == undefined || Builder.ErrorMet == true) { Builder.Clean(); return; }
+            if (exitCode != 0 || Builder.Compiler == undefined || Builder.ErrorMet == true) { Builder.Clean(); return; }
             Electron_FS.renameSync(`${Builder.Outpath}/${Name}.${Builder.Extension}`, `${Builder.Outpath}/${Builder.Name}.${Builder.Extension}`);
             Electron_FS.renameSync(`${Builder.Outpath}/${Name}.yydebug`, `${Builder.Outpath}/${Builder.Name}.yydebug`);
             Builder.Runner.push(Builder.Spawn(Builder.Runtime, Builder.Outpath, Builder.Name));

--- a/build.js
+++ b/build.js
@@ -10,8 +10,9 @@ Builder = Object.assign(Builder, {
     Runtime: "",
     Drive: "",
     Run: function() {
-        // Make sure a project is open!
-        if ($gmedit["gml.Project"].current.version == 0) return;
+        // Make sure a GMS2 project is open!
+        var project = $gmedit["gml.Project"].current;
+        if (Builder.ProjectVersion(project) != 2) return;
 
         // Clear any past errors!
         Builder.Errors = [];

--- a/build.js
+++ b/build.js
@@ -40,8 +40,8 @@ Builder = Object.assign(Builder, {
         }
 
         // Find the temporary directory!
-        let Userpath = "", Temporary = require("os").tmpdir(), Name = $gmedit["gml.Project"].current.name.slice(0, $gmedit["gml.Project"].current.name.lastIndexOf(".")); Builder.Name = Builder.Sanitize(Name);
-        Builder.Runtime = Builder.Preferences.runtimeLocation + Builder.Preferences.runtimeSelection;
+        let Userpath = "", Temporary = require("os").tmpdir();
+        Builder.Runtime = Builder.RuntimeSettings.location + Builder.RuntimeSettings.selection;
         if (Builder.Platform == "win") {
             let User = JSON.parse(Electron_FS.readFileSync(Electron_App.getPath("appData") + "/GameMakerStudio2/um.json"));
             Userpath = `${Electron_App.getPath("appData")}/GameMakerStudio2/${User.username.slice(0, User.username.indexOf("@")) + "_" + User.userID}`;
@@ -52,6 +52,9 @@ Builder = Object.assign(Builder, {
             Temporary = (JSON.parse(Electron_FS.readFileSync(`${Userpath}/local_settings.json`))["machine.General Settings.Paths.IDE.TempFolder"] || `${(Temporary.endsWith("/T") ? Temporary.slice(0, -2) : Temporary)}/GameMakerStudio2`) + "/GMS2TEMP/";
         }
         if (Electron_FS.existsSync(Temporary) == false) Electron_FS.mkdirSync(Temporary);
+        
+        let Name = project.name.slice(0, project.name.lastIndexOf("."));
+        Builder.Name = Builder.Sanitize(Name);
         
         // Create or reuse output tab!
         let Time = new Date(), Create = true;
@@ -91,7 +94,7 @@ Builder = Object.assign(Builder, {
             Builder.Stop();
             return;
         }
-        $gmedit["ui.MainMenu"].menu.items[Builder.MenuIndex + 1].enabled = true;
+        Builder.MenuItems.stop.enabled = true;
 
         // Create substitute drive on Windows!
         if (Builder.Platform == "win") {
@@ -128,7 +131,7 @@ Builder = Object.assign(Builder, {
             Electron_FS.renameSync(`${Builder.Outpath}/${Name}.${Builder.Extension}`, `${Builder.Outpath}/${Builder.Name}.${Builder.Extension}`);
             Electron_FS.renameSync(`${Builder.Outpath}/${Name}.yydebug`, `${Builder.Outpath}/${Builder.Name}.yydebug`);
             Builder.Runner.push(Builder.Spawn(Builder.Runtime, Builder.Outpath, Builder.Name));
-            $gmedit["ui.MainMenu"].menu.items[Builder.MenuIndex + 2].enabled = true;
+            Builder.MenuItems.fork.enabled = true;
             Builder.Compiler = undefined;
         });
     },
@@ -157,7 +160,7 @@ Builder = Object.assign(Builder, {
     },
     Clean: function() {
         // Clean up anything from compile job!
-        for(let i = 1; i < 3; i++) $gmedit["ui.MainMenu"].menu.items[Builder.MenuIndex + i].enabled = false;
+        for (let item of Builder.MenuItems.list) item.enabled = item == Builder.MenuItems.run;
         if (Builder.Drive != "") Builder.RemoveDrive();
         Builder.Output.Write(`Compile Ended: ${Builder.GetTime(new Date())}`);
         Builder.Runner = [];
@@ -236,21 +239,38 @@ Builder = Object.assign(Builder, {
     },
     Display: function() {
         // Display errors in new tab!
-        let GmlProject = $gmedit["gml.Project"].current, GmlFile = $gmedit["gml.file.GmlFile"], Output = new GmlFile(`Compilation Errors`, null, $gmedit["file.kind.gml.KGmlSearchResults"].inst, `// Compile failed with ${Builder.Errors.length} error${(Builder.Errors.length == 1 ? "" : "s")}\n\n`); 
-        Output.Write = (e) => {Output.editor.session.setValue(Output.editor.session.getValue() + "\n" + e); }
-        for(let i = 0; i < Builder.Errors.length; i++) {
-            let Descriptor = Builder.ParseDescriptor(Builder.Errors[i].slice(0, Builder.Errors[i].indexOf(":")).trim()), ErrorText = Builder.Errors[i].slice(Builder.Errors[i].indexOf(":") + 1).trim(), ErrorLine = "";
-            if (GmlProject.yyResourceGUIDs[Descriptor.Asset] != undefined) {
-                let Path = GmlProject.yyResources[GmlProject.yyResourceGUIDs[Descriptor.Asset]].Value.resourcePath.slice(0, (3 + Descriptor.Asset.length) * -1), Location = GmlProject.dir + "/" + Path;
-                switch (Descriptor.Type) {
-                    case "Object": Location += Descriptor.Event; break;
-                    default: Location += Descriptor.Asset; break;
+        let project = $gmedit["gml.Project"].current;
+        let GmlFile = $gmedit["gml.file.GmlFile"];
+        let output = new GmlFile(`Compilation Errors`, null, $gmedit["file.kind.gml.KGmlSearchResults"].inst, `// Compile failed with ${Builder.Errors.length} error${(Builder.Errors.length == 1 ? "" : "s")}\n\n`); 
+        output.Write = (e) => {output.editor.session.setValue(output.editor.session.getValue() + "\n" + e); }
+        for (let error of Builder.Errors) {
+            let colonPos = error.indexOf(":");
+            let descriptor = Builder.ParseDescriptor(error.slice(0, colonPos).trim());
+            let errorText = error.slice(colonPos + 1).trim();
+            let errorLine = "";
+            grabErrorLine: {
+                let resourceGUID = project.yyResourceGUIDs[descriptor.Asset];
+                if (resourceGUID == null) break grabErrorLine;
+                let resource = project.yyResources[resourceGUID];
+                if (resource == null) break grabErrorLine;
+                let resourcePath;
+                if (resource.Value) {
+                    resourcePath = resource.Value.resourcePath;
+                } else if (resource.id) {
+                    resourcePath = resource.id.path;
+                } else break grabErrorLine;
+                let path = resourcePath.slice(0, -(3 + descriptor.Asset.length));
+                switch (descriptor.Type) {
+                    case "Object": path += descriptor.Event; break;
+                    default: path += descriptor.Asset; break;
                 }
-                ErrorLine = $gmedit["electron.FileWrap"].readTextFileSync(Location + ".gml").split("\n")[Descriptor.Line].trim();
-            }
-            Output.Write(`// Error in ${Descriptor.Type[0].toLowerCase() + Descriptor.Type.slice(1)} at @[${Descriptor.Asset}${(Descriptor.Type == "Object" ? `(${Builder.GetEvent(Descriptor.Event)})` : "")}:${Descriptor.Line + 1}]:\n// ${ErrorText}\n${ErrorLine}\n`)
+                try {
+                    errorLine = project.readTextFileSync(path + ".gml").split("\n")[descriptor.Line].trim();
+                } catch (_) {}
+            };
+            output.Write(`// Error in ${descriptor.Type[0].toLowerCase() + descriptor.Type.slice(1)} at @[${descriptor.Asset}${(descriptor.Type == "Object" ? `(${Builder.GetEvent(descriptor.Event)})` : "")}:${descriptor.Line + 1}]:\n// ${errorText}\n${errorLine}\n`)
         }
-        GmlFile.openTab(Output);
+        GmlFile.openTab(output);
     },
     Spawn: function(runtime, output, name) {
         // Spawn an instance of the runner!

--- a/build.js
+++ b/build.js
@@ -133,8 +133,8 @@ Builder = Object.assign(Builder, {
         });
     },
     Stop: function() {
-        // Make sure a project is open!
-        if ($gmedit["gml.Project"].current.version == 0) return;
+        // Make sure a GMS2 project is open!
+        if (Builder.ProjectVersion($gmedit["gml.Project"].current) != 2) return;
 
         // Display errors and kill processes!
         if (Builder.ErrorMet == true) Builder.Display();
@@ -149,8 +149,8 @@ Builder = Object.assign(Builder, {
         }
     },
     Fork: function() {
-        // Make sure a project is open!
-        if ($gmedit["gml.Project"].current.version == 0) return;
+        // Make sure a GMS2 project is open!
+        if (Builder.ProjectVersion($gmedit["gml.Project"].current) != 2) return;
 
         // Fork runner and add it to process list!
         Builder.Runner.push(Builder.Spawn(Builder.Runtime, Builder.Outpath, Builder.Name));

--- a/main.js
+++ b/main.js
@@ -63,6 +63,7 @@ Builder = {
                 Runtimes.push(e);
             }
         });
+        Runtimes.sort((a, b) => a < b ? 1 : -1);
         return Runtimes;
     },
     InitalizeRuntimes: function(set, showWarning) {
@@ -78,7 +79,6 @@ Builder = {
             return;
         }
         
-        set.runtimeList.sort((a, b) => a < b ? 1 : -1);
         if (set.selection.trim() == "" || !set.runtimeList.includes(set.selection)) {
             set.selection = set.runtimeList[0];
         }
@@ -197,11 +197,11 @@ Builder = {
                 label.appendChild(Preferences.createFuncAnchor("Rescan", function() {
                     runtimeListSelect.innerHTML = "";
                     for (let rt of Builder.GetRuntimes(set.location)) {
-                        let option = document.createElement(option);
+                        let option = document.createElement("option");
                         option.innerHTML = option.value = rt;
                         runtimeListSelect.appendChild(option);
                     }
-                    runtimeLocationInput.value = set.location;
+                    runtimeListSelect.value = set.selection;
                     Builder.SavePreferences();
                 }));
                 label.appendChild(document.createTextNode(")"));

--- a/main.js
+++ b/main.js
@@ -17,7 +17,9 @@ Builder = {
         runtimeList: []
     },
     SavePreferences: function() {
-        Electron_FS.writeFileSync(this.PreferencesPath, JSON.stringify(this.Preferences));
+        Electron_FS.writeFileSync(this.PreferencesPath, JSON.stringify(this.Preferences, (k, v) => {
+            return k == "runtimeList" ? undefined : v;
+        }, "    "));
     },
     LoadPreferences: function() {
         return Object.assign(this.Preferences, JSON.parse(Electron_FS.readFileSync(this.PreferencesPath)));

--- a/main.js
+++ b/main.js
@@ -39,7 +39,7 @@ Builder = {
         if (typeof(project.version) == "object") {
             switch (project.version.config.projectMode) {
                 case "gms2": return 2;
-                case "v1": return 1;
+                case "gms1": return 1;
             }
             return -1;
         }

--- a/main.js
+++ b/main.js
@@ -1,8 +1,8 @@
 if (require("os").type().includes("Darwin")) process.env.ProgramData = "/Users/Shared";
 
 Builder = {
-    Version: "1.2",
-    MenuIndex: -1,
+    Version: "1.23",
+    MenuItems: { list: [], run: null, stop: null, fork: null },
     Platform: require("os").type(),
     PreferencesPath: Electron_App.getPath("userData") + "/GMEdit/config/Builder-preferences.json",
     PreferencesElement: document.createElement("div"),
@@ -12,10 +12,20 @@ Builder = {
         stopCompile: false,
         displayLine: true,
         forkArguments: "",
-        runtimeLocation: process.env.ProgramData + "/GameMakerStudio2/Cache/runtimes/",
-        runtimeSelection: "",
-        runtimeList: []
+        runtimeSettings: {
+            Stable: {
+                location: process.env.ProgramData + "/GameMakerStudio2/Cache/runtimes/",
+                runtimeList: [],
+                selection: ""
+            },
+            Beta: {
+                location: process.env.ProgramData + "/GameMakerStudio2-Beta/Cache/runtimes/",
+                runtimeList: [],
+                selection: ""
+            }
+        }
     },
+    RuntimeSettings: null,
     SavePreferences: function() {
         Electron_FS.writeFileSync(this.PreferencesPath, JSON.stringify(this.Preferences, (k, v) => {
             return k == "runtimeList" ? undefined : v;
@@ -55,6 +65,24 @@ Builder = {
         });
         return Runtimes;
     },
+    InitalizeRuntimes: function(set, showWarning) {
+        // [Re-]gather list of runtimes
+        set.runtimeList = this.GetRuntimes(set.location);
+        
+        if (set.runtimeList.length <= 0) {
+            if (showWarning) Electron_Dialog.showMessageBox({
+                type: "warning",
+                message: `builder was unable to find any runtimes in ${set.location}, please verify your runtime location and rescan.`
+            });
+            set.selection = "";
+            return;
+        }
+        
+        set.runtimeList.sort((a, b) => a < b ? 1 : -1);
+        if (set.selection.trim() == "" || !set.runtimeList.includes(set.selection)) {
+            set.selection = set.runtimeList[0];
+        }
+    },
     Initalize: function() {
         // Check if platform is supported
         this.Platform = (this.Platform.includes("Windows") ? "win" : (this.Platform.includes("Darwin") ? "mac" : "unknown"));
@@ -67,8 +95,12 @@ Builder = {
         if (Electron_FS.existsSync(this.PreferencesPath) == true) {
             try {
                 this.Preferences = this.LoadPreferences();
-                if (this.Preferences.runtimeSelection.trim() == "" && this.Preferences.runtimeList > 0) {
-                    this.Preferences.runtimeSelection = this.Preferences.runtimeList[0];   
+                if (this.Preferences.runtimeLocation != null) { // migration
+                    this.Preferences.runtimeSettings.Stable.location = this.Preferences.runtimeLocation;
+                    delete this.Preferences.runtimeLocation;
+                    this.Preferences.runtimeSettings.Stable.selection = this.Preferences.runtimeSelection;
+                    delete this.Preferences.runtimeSelection;
+                    delete this.Preferences.runtimeList;
                 }
             } catch(e) {
                 console.error("builder - Failed to read or parse preferences file.");
@@ -76,14 +108,11 @@ Builder = {
         } else {
             this.SavePreferences();
         }
-        this.Preferences.runtimeList = [];
-
-        // Gather list of runtimes
-        this.Preferences.runtimeList = this.GetRuntimes(this.Preferences.runtimeLocation);
-        if (this.Preferences.runtimeList.length <= 0) {
-            Electron_Dialog.showMessageBox({type: "warning", message: "builder was unable to find any runtimes, please verify your runtime location and rescan."});
+        for (let [key, val] of Object.entries(this.Preferences.runtimeSettings)) {
+            this.InitalizeRuntimes(val, key == "Stable");
         }
-        Builder.LoadKeywords(this.Preferences.runtimeLocation + this.Preferences.runtimeSelection);
+        
+        Builder.LoadKeywords(this.Preferences.runtimeSettings.Stable.location + this.Preferences.runtimeSettings.Stable.selection);
         return true;
     }
 };
@@ -99,41 +128,88 @@ Builder = {
 
             // Create main menu items!
             let MainMenu = $gmedit["ui.MainMenu"].menu;
-            MainMenu.items.forEach((item, index) => {if (item.label.toLowerCase() == "close project") {
-                Builder.MenuIndex = ++index + 1;
-                MainMenu.insert(index, new Electron_MenuItem({type: "separator"}));
-                MainMenu.insert(++index, new Electron_MenuItem({label: "Run", accelerator: "F5", enabled: false, click: Builder.Run}));
-                MainMenu.insert(++index, new Electron_MenuItem({label: "Stop", accelerator: "F6", enabled: false, click: Builder.Stop}));
-                MainMenu.insert(++index, new Electron_MenuItem({label: "Fork", accelerator: "F7", enabled: false, click: Builder.Fork}));
-                return;
-            }});
+            for (let [index, mainMenuItem] of MainMenu.items.entries()) {
+                if (mainMenuItem.id != "close-project") continue;
+                Builder.MenuItems.list = [
+                    new Electron_MenuItem({
+                        id: "builder-sep",
+                        type: "separator"
+                    }),
+                    Builder.MenuItems.run = new Electron_MenuItem({
+                        id: "builder-run",
+                        label: "Run",
+                        accelerator: "F5",
+                        enabled: false,
+                        click: Builder.Run
+                    }),
+                    Builder.MenuItems.stop = new Electron_MenuItem({
+                        id: "builder-stop",
+                        label: "Stop",
+                        accelerator: "F6",
+                        enabled: false,
+                        click: Builder.Stop
+                    }),
+                    Builder.MenuItems.fork = new Electron_MenuItem({
+                        id: "builder-fork",
+                        label: "Fork",
+                        accelerator: "F7",
+                        enabled: false,
+                        click: Builder.Fork
+                    })
+                ];
+                for (let newItem of Builder.MenuItems.list) {
+                    MainMenu.insert(++index, newItem);
+                }
+                break;
+            }
+            if (Builder.MenuItems.run == null) return; // probably running in GMLive.js
 
             // Create preferences menu!
             let Preferences = $gmedit["ui.Preferences"];
-            Preferences.addText(Builder.PreferencesElement, "").innerHTML = "<b>Runtime Settings</b>";
-            Preferences.addInput(Builder.PreferencesElement, "Runtime Location", Builder.Preferences.runtimeLocation, (value) => { Builder.Preferences.runtimeLocation = value; Builder.SavePreferences(); });
-            Preferences.addButton(Builder.PreferencesElement, "Reset Location", () => { 
-                Builder.Preferences.runtimeLocation = process.env.ProgramData + "/GameMakerStudio2/Cache/runtimes/";
-                Builder.PreferencesElement.children[1].children[1].value = Builder.Preferences.runtimeLocation;
-                Builder.SavePreferences();
-            });
-            Preferences.addButton(Builder.PreferencesElement, "Rescan Runtimes", () => {
-                let Selection = Builder.PreferencesElement.children[4].children[1];
-                Selection.innerHTML = "";
-                Builder.Preferences.runtimeList = Builder.GetRuntimes(Builder.Preferences.runtimeLocation);
-                Builder.Preferences.runtimeList.forEach((e, i) => {
-                    let Option = document.createElement("option");
-                    Option.value = e;
-                    Option.innerHTML = Option.value;
-                    Selection.appendChild(Option);
+            for (let [key, set] of Object.entries(Builder.Preferences.runtimeSettings)) {
+                let runtimeGroup = Preferences.addGroup(Builder.PreferencesElement, `Runtime Settings (${key})`);
+                let element, label;
+                
+                element = Preferences.addInput(runtimeGroup, "Runtime Location", set.location, (value) => {
+                    set.location = value; Builder.SavePreferences();
                 });
-            });
-            Preferences.addDropdown(Builder.PreferencesElement, "Current Runtime", Builder.Preferences.runtimeSelection, Builder.Preferences.runtimeList, (value) => {
-                Builder.Preferences.runtimeSelection = value;
-                Builder.SavePreferences();
-            });
+                let runtimeLocationInput = element.querySelector("input");
+                label = element.querySelector("label");
+                label.appendChild(document.createTextNode(" ("));
+                label.appendChild(Preferences.createFuncAnchor("Reset", function() {
+                    switch (key) {
+                        case "Stable": set.location = process.env.ProgramData + "/GameMakerStudio2/Cache/runtimes/"; break;
+                        case "Beta": set.location = process.env.ProgramData + "/GameMakerStudio2-Beta/Cache/runtimes/"; break;
+                        default: return;
+                    }
+                    runtimeLocationInput.value = set.location;
+                    Builder.SavePreferences();
+                }));
+                label.appendChild(document.createTextNode(")"));
+                
+                element = Preferences.addDropdown(runtimeGroup, "Current Runtime", set.selection, set.runtimeList, (value) => {
+                    set.selection = value;
+                    Builder.SavePreferences();
+                });
+                let runtimeListSelect = element.querySelector("select");
+                label = element.querySelector("label");
+                label.appendChild(document.createTextNode(" ("));
+                label.appendChild(Preferences.createFuncAnchor("Rescan", function() {
+                    runtimeListSelect.innerHTML = "";
+                    for (let rt of Builder.GetRuntimes(set.location)) {
+                        let option = document.createElement(option);
+                        option.innerHTML = option.value = rt;
+                        runtimeListSelect.appendChild(option);
+                    }
+                    runtimeLocationInput.value = set.location;
+                    Builder.SavePreferences();
+                }));
+                label.appendChild(document.createTextNode(")"));
+            }
+            
+            let settingsGroup = Preferences.addGroup(Builder.PreferencesElement, "Builder Settings");
             if (Builder.Platform =="win") {
-                Preferences.addButton(Builder.PreferencesElement, "Clean Virtual Drives", () => {
+                Preferences.addButton(settingsGroup, "Clean Virtual Drives", () => {
                     let Command = require("child_process"), Drives = window.localStorage.getItem("builder:drives") || "";
                     for(let i = 0; i < Drives.length; i++) {
                         try {
@@ -144,22 +220,13 @@ Builder = {
                     Electron_Dialog.showMessageBox({type: "info", title: "Builder", message: "Finished cleaning virtual drives."});
                 });
             }
-            Preferences.addText(Builder.PreferencesElement, "").innerHTML = "<b>Builder Settings</b>";
-            Preferences.addInput(Builder.PreferencesElement, "Fork Arguments", Builder.Preferences.forkArguments, (value) => { Builder.Preferences.forkArguments = value; Builder.SavePreferences(); });
-            Preferences.addCheckbox(Builder.PreferencesElement, "Reuse Output Tab", Builder.Preferences.reuseTab, (value) => { Builder.Preferences.reuseTab = value; Builder.SavePreferences(); });
-            Preferences.addCheckbox(Builder.PreferencesElement, "Save Upon Compile", Builder.Preferences.saveCompile, (value) => { Builder.Preferences.saveCompile = value; Builder.SavePreferences(); });
-            Preferences.addCheckbox(Builder.PreferencesElement, "Stop Upon Compile", Builder.Preferences.stopCompile, (value) => { Builder.Preferences.stopCompile = value; Builder.SavePreferences(); });
-            Preferences.addCheckbox(Builder.PreferencesElement, "Display Line After Fatal Error", Builder.Preferences.displayLine, (value) => { Builder.Preferences.displayLine = value; Builder.SavePreferences(); });
+            Preferences.addInput(settingsGroup, "Fork Arguments", Builder.Preferences.forkArguments, (value) => { Builder.Preferences.forkArguments = value; Builder.SavePreferences(); });
+            Preferences.addCheckbox(settingsGroup, "Reuse Output Tab", Builder.Preferences.reuseTab, (value) => { Builder.Preferences.reuseTab = value; Builder.SavePreferences(); });
+            Preferences.addCheckbox(settingsGroup, "Save Upon Compile", Builder.Preferences.saveCompile, (value) => { Builder.Preferences.saveCompile = value; Builder.SavePreferences(); });
+            Preferences.addCheckbox(settingsGroup, "Stop Upon Compile", Builder.Preferences.stopCompile, (value) => { Builder.Preferences.stopCompile = value; Builder.SavePreferences(); });
+            Preferences.addCheckbox(settingsGroup, "Display Line After Fatal Error", Builder.Preferences.displayLine, (value) => { Builder.Preferences.displayLine = value; Builder.SavePreferences(); });
             Preferences.addButton(Builder.PreferencesElement, "Back", () => { Preferences.setMenu(Preferences.menuMain); Builder.SavePreferences(); });
             Preferences.addText(Builder.PreferencesElement, `builder v${Builder.Version} by nommiin`);
-            let buildMain = Preferences.buildMain;
-            Preferences.buildMain = function(arguments) {
-                let Return = buildMain.apply(this, arguments);
-                Preferences.addButton(Return, "builder Settings", function() {
-                    Preferences.setMenu(Builder.PreferencesElement);
-                })
-                return Return;
-            }
 
             // Add ace commands!
             let AceCommands = $gmedit["ace.AceCommands"];
@@ -176,19 +243,32 @@ Builder = {
                 let Return = finishedIndexing.apply(this, arguments);
                 if (Builder.ProjectVersion(this) != 2) return Return;
                 this.configs = ["default"];
-                JSON.parse(Electron_FS.readFileSync(Project.current.path)).configs.forEach((e) => {
-                    e.split(";").forEach((e) => { if (this.configs.includes(e) == false) this.configs.push(e); });
-                });
+                let projectContent = Electron_FS.readFileSync(Project.current.path, "utf8");
+                if ($gmedit["yy.YyJson"].isExtJson(projectContent)) { // 2.3
+                    function addConfigRec(project, config) {
+                        if (!project.configs.includes(config.name)) project.configs.push(config.name);
+                        for (let childConfig of config.children) addConfigRec(project, childConfig);
+                    }
+                    addConfigRec(this, $gmedit["yy.YyJson"].parse(projectContent).configs);
+                } else { // 2.2
+                    for (let configData of JSON.parse(projectContent).configs) {
+                        for (let configName of configData.split(";")) {
+                            if (!this.configs.includes(configName)) this.configs.push(configName);
+                        }
+                    }
+                }
                 this.config = (this.configs.includes(window.localStorage.getItem(`config:${Project.current.path}`)) ? window.localStorage.getItem(`config:${Project.current.path}`) : "default");
                 window.localStorage.setItem(`config:${Project.current.path}`, this.config);  
-                let TreeView = $gmedit["ui.treeview.TreeView"],  Configurations = undefined;
-                document.querySelectorAll(".dir").forEach((e) => {
-                    if (e.textContent == "Configs") {
-                        Configurations = e;
-                        return;
+                let TreeView = $gmedit["ui.treeview.TreeView"];
+                let Configurations = undefined;
+                for (let dir of document.querySelectorAll(".dir")) {
+                    if (dir.textContent == "Configs") {
+                        Configurations = dir;
+                        break;
                     }
-                });
+                }
                 Configurations = Configurations || TreeView.makeAssetDir("Configs", "");
+                
                 this.configs.forEach((e) => {
                     let Configuration = TreeView.makeItem(e);
                     Configuration.addEventListener("dblclick", function() {
@@ -199,30 +279,37 @@ Builder = {
                     Configurations.treeItems.appendChild(Configuration);
                 });
                 TreeView.element.appendChild(Configurations);
+                
                 document.getElementById("project-name").innerText = `${Project.current.displayName} (${this.config})`;
                 return Return;
             }
-        }
-    });
-
-    GMEdit.on("projectOpen", function() {
-        let MainMenu = $gmedit["ui.MainMenu"].menu;
-        if (Builder.MenuIndex != -1) {
-            for(let i = 0; i < 3; i++) {
-                MainMenu.items[Builder.MenuIndex + i].enabled = false;
-            }
             
-            if (Builder.ProjectVersion($gmedit["gml.Project"].current) == 2) {
-                MainMenu.items[Builder.MenuIndex].enabled = true;
-                Builder.LoadKeywords(Builder.Preferences.runtimeLocation + Builder.Preferences.runtimeSelection);
-            }
-        }
-    });
-
-    GMEdit.on("projectClose", function() {
-        let MainMenu = $gmedit["ui.MainMenu"].menu;
-        if (Builder.MenuIndex != -1) for(let i = 0; i < 3; i++) {
-            MainMenu.items[Builder.MenuIndex + i].enabled = false;
+            GMEdit.on("preferencesBuilt", (e) => {
+                Preferences.addButton(e.target, "builder Settings", () => {
+                    Preferences.setMenu(Builder.PreferencesElement);
+                });
+            });
+        
+            GMEdit.on("projectOpen", function() {
+                for (let item of Builder.MenuItems.list) item.enabled = false;
+                let project = $gmedit["gml.Project"].current;
+                if (Builder.ProjectVersion(project) == 2) {
+                    Builder.MenuItems.run.enabled = true;
+                    let runtime;
+                    if (project.version.name == "v23"
+                        && Builder.Preferences.runtimeSettings.Stable.selection < "runtime-2.3"
+                        && Builder.Preferences.runtimeSettings.Beta.selection != ""
+                    ) {
+                        runtime = Builder.Preferences.runtimeSettings.Beta;
+                    } else runtime = Builder.Preferences.runtimeSettings.Stable;
+                    Builder.RuntimeSettings = runtime;
+                    Builder.LoadKeywords(runtime.location + runtime.selection);
+                }
+            });
+        
+            GMEdit.on("projectClose", function() {
+                for (let item of Builder.MenuItems.list) item.enabled = false;
+            });
         }
     });
 })();

--- a/main.js
+++ b/main.js
@@ -205,19 +205,21 @@ Builder = {
 
     GMEdit.on("projectOpen", function() {
         let MainMenu = $gmedit["ui.MainMenu"].menu;
-        for(let i = 0; i < 3; i++) {
-            MainMenu.items[Builder.MenuIndex + i].enabled = false;
-        }
-        
-        if (Builder.ProjectVersion($gmedit["gml.Project"].current) == 2) {
-            MainMenu.items[Builder.MenuIndex].enabled = true;
-            Builder.LoadKeywords(Builder.Preferences.runtimeLocation + Builder.Preferences.runtimeSelection);
+        if (Builder.MenuIndex != -1) {
+            for(let i = 0; i < 3; i++) {
+                MainMenu.items[Builder.MenuIndex + i].enabled = false;
+            }
+            
+            if (Builder.ProjectVersion($gmedit["gml.Project"].current) == 2) {
+                MainMenu.items[Builder.MenuIndex].enabled = true;
+                Builder.LoadKeywords(Builder.Preferences.runtimeLocation + Builder.Preferences.runtimeSelection);
+            }
         }
     });
 
     GMEdit.on("projectClose", function() {
         let MainMenu = $gmedit["ui.MainMenu"].menu;
-        for(let i = 0; i < 3; i++) {
+        if (Builder.MenuIndex != -1) for(let i = 0; i < 3; i++) {
             MainMenu.items[Builder.MenuIndex + i].enabled = false;
         }
     });


### PR DESCRIPTION
- Fixed 2.3 error parsing (resource.Value.resourcePath -> resource.id.path)
- Added some safety checks
- Made shortcut functions check for version via Builder.ProjectVersion (prevents from erroring when using on a GMS1 project)
- Added a separate set of options for Beta IDE, with auto-detection of what should be used.
- Sets of controls are now enclosed in fieldsets like the rest of updated settings UI is.
- Menu items are now references instead of modifying menu contents by index offset.
- Runtimes are now shown from newest to oldest, newest one being picked by default.
- Minor cleanup where appropriate (e.g. using a for-of loop instead of a forEach to break out of it early)

![image](https://user-images.githubusercontent.com/731492/83551520-1e52ee80-a511-11ea-9611-bf70d282792d.png)
