### PR TITLE
Added error handling for GetRuntimes

### DIFF
--- a/main.js
+++ b/main.js
@@ -293,8 +293,8 @@ Builder = {
                     Preferences.setMenu(Builder.PreferencesElement);
                 });
             });
-        
-            GMEdit.on("projectOpen", function() {
+            
+            function projectOpened() {
                 for (let item of Builder.MenuItems.list) item.enabled = false;
                 let project = $gmedit["gml.Project"].current;
                 if (Builder.ProjectVersion(project) == 2) {
@@ -309,11 +309,14 @@ Builder = {
                     Builder.RuntimeSettings = runtime;
                     Builder.LoadKeywords(runtime.location + runtime.selection);
                 }
-            });
+            }
+            GMEdit.on("projectOpen", projectOpened);
         
             GMEdit.on("projectClose", function() {
                 for (let item of Builder.MenuItems.list) item.enabled = false;
             });
+            
+            projectOpened();
         }
     });
 })();

--- a/main.js
+++ b/main.js
@@ -57,12 +57,16 @@ Builder = {
     },
     GetRuntimes: function(path) {
         let Runtimes = [];
-        Electron_FS.readdirSync(path).forEach((e) => {
-            let RuntimeStat = Electron_FS.statSync(path + e);
-            if (RuntimeStat.isDirectory() == true) {
-                Runtimes.push(e);
-            }
-        });
+        try {
+            Electron_FS.readdirSync(path).forEach((e) => {
+                let RuntimeStat = Electron_FS.statSync(path + e);
+                if (RuntimeStat.isDirectory() == true) {
+                    Runtimes.push(e);
+                }
+            });
+        } catch (x) {
+            console.warn(`Failed to index ${path}:`, x);
+        }
         Runtimes.sort((a, b) => a < b ? 1 : -1);
         return Runtimes;
     },


### PR DESCRIPTION
The function throws if the folder is missing and apparently the original "couldn't find runtimes" error box could not realistically trigger if you really did not have GMS2 installed at the usual spot (only if the folder was there but empty)