### PR TITLE
Adding Preference for opening existing output tab on compile.

### DIFF
--- a/build.js
+++ b/build.js
@@ -61,7 +61,10 @@ Builder = Object.assign(Builder, {
         if (Builder.Preferences.reuseTab == true) {
            document.querySelectorAll(".chrome-tab").forEach((e) => {
                 if (e.gmlFile.output != undefined || e.gmlFile.output == true) {
-                    $gmedit["ui.ChromeTabs"].impl.setCurrentTab(e);
+                    //Check for Preference of opening existing tab on compile
+                    if (Builder.Preferences.openOutputTabOnCompile == true) {
+                        $gmedit["ui.ChromeTabs"].impl.setCurrentTab(e);
+                    }
                     e.childNodes.forEach((e) => { if (e.className == "chrome-tab-title") e.innerText = `Output (${Builder.GetTime(Time)})`; })
                     e.gmlFile.editor.session.setValue("");
                     Builder.Output = e.gmlFile;
@@ -78,7 +81,10 @@ Builder = Object.assign(Builder, {
                 if (aceEditor.session.gmlFile == this) {
                     aceEditor.gotoLine(aceEditor.session.getLength());
                 }
+
             }
+            
+            //If creating new output tab, always open it
             GmlFile.openTab(Builder.Output);
         }
         Builder.Output.editor.session.setValue(`Compile Started: ${Builder.GetTime(Time)}\nUsing Runtime: ${Builder.Preferences.runtimeSelection}`);

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ Builder = {
     PreferencesElement: document.createElement("div"),
     Preferences: {
         reuseTab: false,
+        openOutputTabOnCompile: true,
         saveCompile: false,
         stopCompile: false,
         displayLine: true,
@@ -226,6 +227,7 @@ Builder = {
             }
             Preferences.addInput(settingsGroup, "Fork Arguments", Builder.Preferences.forkArguments, (value) => { Builder.Preferences.forkArguments = value; Builder.SavePreferences(); });
             Preferences.addCheckbox(settingsGroup, "Reuse Output Tab", Builder.Preferences.reuseTab, (value) => { Builder.Preferences.reuseTab = value; Builder.SavePreferences(); });
+            Preferences.addCheckbox(settingsGroup, "Open Existing Output Tab on Compile", Builder.Preferences.openOutputTabOnCompile, (value) => { Builder.Preferences.openOutputTabOnCompile = value; Builder.SavePreferences(); });
             Preferences.addCheckbox(settingsGroup, "Save Upon Compile", Builder.Preferences.saveCompile, (value) => { Builder.Preferences.saveCompile = value; Builder.SavePreferences(); });
             Preferences.addCheckbox(settingsGroup, "Stop Upon Compile", Builder.Preferences.stopCompile, (value) => { Builder.Preferences.stopCompile = value; Builder.SavePreferences(); });
             Preferences.addCheckbox(settingsGroup, "Display Line After Fatal Error", Builder.Preferences.displayLine, (value) => { Builder.Preferences.displayLine = value; Builder.SavePreferences(); });


### PR DESCRIPTION
With my setup I always have the output tab shown aside, so I don't need the output tab to be opened if it already exists. This change adds a preference to prevent that from happening.

I'm sure it's kind of a niche preference, but figured  I'd open a PR and see what you think.